### PR TITLE
Run CI on push to main, rename job to macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -9,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  macos:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `push` trigger so CI runs post-merge (matches Rocky)
- Rename job key from `test` to `macos` to match branch protection and standardize naming across argylebits repos

## Note
Branch protection already requires `macos` — this PR makes CI match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)