### PR TITLE
Fix version tag resolution in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
             runner: macos-26
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build release binary
         run: swift build -c release --arch ${{ matrix.arch }}


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 0` to checkout in build jobs so `git describe --tags` resolves the version tag correctly

## Problem
`actions/checkout@v4` defaults to shallow clone with `--no-tags`, causing VersionPlugin to fall back to commit hash instead of the tag version.

## Test plan
- [ ] Tag v0.1.1 after merge, verify `kolache --version` shows `Kolache v0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)